### PR TITLE
Fix Terminator config deployment

### DIFF
--- a/InstallScripts/kali-install.sh
+++ b/InstallScripts/kali-install.sh
@@ -55,7 +55,7 @@ apt install -y terminator
 
 # Set a few terminator preferences
 install -D /dev/null ~/.config/terminator/config
-echo "[global_config]\n  inactive_color_offset = 1.0\n[keybindings]\n[profiles]\n  [[default]]\n    cursor_color = \"#aaaaaa\"\n    foreground_color = \"#ffffff\"\n    scrollback_lines = 2500\n[layouts]\n  [[default]]\n    [[[child1]]]\n      parent = window0\n      type = Terminal\n    [[[window0]]]\n      parent = \"\"\n      type = Window\n[plugins]" > ~/.config/terminator/config
+echo -e "[global_config]\n  inactive_color_offset = 1.0\n[keybindings]\n[profiles]\n  [[default]]\n    cursor_color = \"#aaaaaa\"\n    foreground_color = \"#ffffff\"\n    scrollback_lines = 2500\n[layouts]\n  [[default]]\n    [[[child1]]]\n      parent = window0\n      type = Terminal\n    [[[window0]]]\n      parent = \"\"\n      type = Window\n[plugins]" > ~/.config/terminator/config
 
 # Install GDB PEDA 
 git clone https://github.com/longld/peda.git ~/.peda


### PR DESCRIPTION
Added -e to interpret escapes so \n works for Terminator config. Seems this was a regression in 320af4ddfe7e4e714d6451e8cb59683f8963de3e